### PR TITLE
Add person class for retrieval of persons

### DIFF
--- a/pipedrive/base.py
+++ b/pipedrive/base.py
@@ -37,7 +37,6 @@ class PipedriveAPI(object):
             sleep(self.retry_backoff_base ** attempt)
             return self.send_request(method, path, params, data, attempt + 1)
 
-
         if self.api_token in (None, ''):
             class MockResponse(requests.Response):
                 def json(self):

--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -3,6 +3,7 @@ from schematics.models import Model
 from schematics.types import (
     StringType, IntType, DecimalType, DateTimeType, EmailType, BooleanType
 )
+from schematics.types.base import BaseType
 from schematics.types.compound import ListType, ModelType
 from types import (
     PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime
@@ -106,7 +107,6 @@ class Activity(Model):
     due_date = PipedriveDate(required=False)
 
 
-
 class ActivityType(Model):
     """
     Represents the possible types of activities.
@@ -116,3 +116,16 @@ class ActivityType(Model):
     key_string = StringType(required=False)
     icon_key = StringType(required=False)
     is_custom_flag = BooleanType(required=False)
+
+
+class Person(Model):
+    """
+    Model for Pipedrive persons.
+    """
+    name = StringType(required=True)
+    owner_id = PipedriveModelType(User, required=False)
+    org_id = PipedriveModelType(Organization, required=False)
+    email = BaseType(required=False)
+    phone = BaseType(required=False)
+    visible_to = IntType(required=False)
+    add_time = PipedriveDateTime(required=False)

--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -122,6 +122,7 @@ class Person(Model):
     """
     Model for Pipedrive persons.
     """
+    id = IntType(required=False)
     name = StringType(required=True)
     owner_id = PipedriveModelType(User, required=False)
     org_id = PipedriveModelType(Organization, required=False)

--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -3,8 +3,7 @@ from schematics.models import Model
 from schematics.types import (
     StringType, IntType, DecimalType, DateTimeType, EmailType, BooleanType
 )
-from schematics.types.base import BaseType
-from schematics.types.compound import ListType, ModelType
+from schematics.types.compound import ListType, ModelType, DictType
 from types import (
     PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime
 )
@@ -126,7 +125,7 @@ class Person(Model):
     name = StringType(required=True)
     owner_id = PipedriveModelType(User, required=False)
     org_id = PipedriveModelType(Organization, required=False)
-    email = BaseType(required=False)
-    phone = BaseType(required=False)
+    email = ListType(DictType(StringType), required=False)
+    phone = ListType(DictType(StringType), required=False)
     visible_to = IntType(required=False)
     add_time = PipedriveDateTime(required=False)

--- a/pipedrive/resources.py
+++ b/pipedrive/resources.py
@@ -2,8 +2,9 @@
 from base import BaseResource, PipedriveAPI, CollectionResponse, dict_to_model
 from models import (
     User, Pipeline, Stage, SearchResult, Organization,
-    Deal, Activity, ActivityType
+    Deal, Activity, ActivityType, Person
 )
+
 
 class UserResource(BaseResource):
     MODEL_CLASS = User
@@ -239,6 +240,43 @@ class ActivityTypeResource(BaseResource):
         response = self._bulk_delete(activities_ids)
         return response.json()
 
+
+class PersonResource(BaseResource):
+    MODEL_CLASS = Person
+    API_ACESSOR_NAME = 'person'
+    LIST_REQ_PATH = '/persons'
+    DETAIL_REQ_PATH = '/persons/{id}'
+    FIND_REQ_PATH = '/persons/find'
+    RELATED_ENTITIES_PATH = '/persons/{id}/{entity}'
+
+    def detail(self, resource_ids):
+        response = self._detail(resource_ids)
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def create(self, person):
+        response = self._create(data=person.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def update(self, person):
+        response = self._update(person.id, data=person.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def list(self, **params):
+        return CollectionResponse(self._list(params=params), self.MODEL_CLASS)
+
+    def find(self, term, **params):
+        return CollectionResponse(self._find(term, params=params), self.MODEL_CLASS)
+
+    def delete(self, person):
+        response = self._delete(person.id)
+        return response.json()
+
+    def bulk_delete(self, persons):
+        person_ids = [person.id for person in persons]
+
+        response = self._bulk_delete(person_ids)
+        return response.json()
+
 # Registers the resources
 for resource_class in [
     UserResource,
@@ -249,5 +287,6 @@ for resource_class in [
     DealResource,
     ActivityResource,
     ActivityTypeResource,
+    PersonResource,
 ]:
     PipedriveAPI.register_resource(resource_class)

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -4,6 +4,7 @@ from schematics.types import DateType, BaseType
 from schematics.exceptions import ConversionError
 from base import dict_to_model
 
+
 class PipedriveDate(DateType):
     def to_native(self, value, context=None):
         return datetime.datetime.strptime(value, "%Y-%m-%d")


### PR DESCRIPTION
Able to query, insert, update and delete `Person`s. I wasn't entirely sure how the `email` and `phone` fields should be handled, since they require an array and I couldn't find those. These work with the `BaseType` classes. However, that class is probably not meant to be used like that. Unfortunately I couldn't get anywhere trying to write my own, so I kept it at this. Let me know what you think about it, and I'll update it some.

I'm adding this, because I want to be able to add `Note`s to Pipedrive and I thought I might as well contribute to this repo. In my specific use case I need `Person`s before I can use `Note`s. You can expect a PR for that class as well.