### PR TITLE
Fix model conversion error

### DIFF
--- a/pipedrive/base.py
+++ b/pipedrive/base.py
@@ -37,7 +37,6 @@ class PipedriveAPI(object):
             sleep(self.retry_backoff_base ** attempt)
             return self.send_request(method, path, params, data, attempt + 1)
 
-
         if self.api_token in (None, ''):
             class MockResponse(requests.Response):
                 def json(self):

--- a/pipedrive/fields.py
+++ b/pipedrive/fields.py
@@ -64,6 +64,10 @@ class ProductField(FieldModel):
     FIELD_PARENT_TYPE = 'productField'
 
 
+class NoteField(FieldModel):
+    FIELD_PARENT_TYPE = 'noteField'
+
+
 class DealFieldResource(FieldResource):
     FIELD_CLASS = DealField
     API_ACESSOR_NAME = 'dealField'
@@ -92,7 +96,15 @@ class ProductFieldResource(FieldResource):
     DETAIL_REQ_PATH = '/productFields/{id}'
 
 
+class NoteFieldResource(FieldResource):
+    FIELD_CLASS = NoteField
+    API_ACESSOR_NAME = 'noteField'
+    LIST_REQ_PATH = '/noteFields'
+    DETAIL_REQ_PATH = '/noteFields/{id}'
+
+
 PipedriveAPI.register_resource(DealFieldResource)
 PipedriveAPI.register_resource(OrganizationFieldResource)
 PipedriveAPI.register_resource(PersonFieldResource)
 PipedriveAPI.register_resource(ProductFieldResource)
+PipedriveAPI.register_resource(NoteFieldResource)

--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -3,7 +3,7 @@ from schematics.models import Model
 from schematics.types import (
     StringType, IntType, DecimalType, DateTimeType, EmailType, BooleanType
 )
-from schematics.types.compound import ListType, ModelType
+from schematics.types.compound import ListType, ModelType, DictType
 from types import (
     PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime
 )
@@ -106,7 +106,6 @@ class Activity(Model):
     due_date = PipedriveDate(required=False)
 
 
-
 class ActivityType(Model):
     """
     Represents the possible types of activities.
@@ -116,3 +115,28 @@ class ActivityType(Model):
     key_string = StringType(required=False)
     icon_key = StringType(required=False)
     is_custom_flag = BooleanType(required=False)
+
+
+class Person(Model):
+    """
+    Model for Pipedrive persons.
+    """
+    id = IntType(required=False)
+    name = StringType(required=True)
+    owner_id = PipedriveModelType(User, required=False)
+    org_id = PipedriveModelType(Organization, required=False)
+    email = ListType(DictType(StringType), required=False)
+    phone = ListType(DictType(StringType), required=False)
+    visible_to = IntType(required=False)
+    add_time = PipedriveDateTime(required=False)
+
+
+class Note(Model):
+    """
+    Model for Pipedrive notes.
+    """
+    id = IntType(required=False)
+    content = StringType(required=True)
+    deal_id = PipedriveModelType(Deal, required=False)
+    person_id = PipedriveModelType(Person, required=False)
+    org_id = PipedriveModelType(Organization, required=False)

--- a/pipedrive/models.py
+++ b/pipedrive/models.py
@@ -5,7 +5,7 @@ from schematics.types import (
 )
 from schematics.types.compound import ListType, ModelType, DictType
 from types import (
-    PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime
+    PipedriveDateTime, PipedriveModelType, PipedriveDate, PipedriveTime, PipedriveEmailType, PipedrivePhonenumberType
 )
 
 
@@ -125,8 +125,8 @@ class Person(Model):
     name = StringType(required=True)
     owner_id = PipedriveModelType(User, required=False)
     org_id = PipedriveModelType(Organization, required=False)
-    email = ListType(DictType(StringType), required=False)
-    phone = ListType(DictType(StringType), required=False)
+    email = PipedriveEmailType(required=False)
+    phone = PipedrivePhonenumberType(required=False)
     visible_to = IntType(required=False)
     add_time = PipedriveDateTime(required=False)
 

--- a/pipedrive/resources.py
+++ b/pipedrive/resources.py
@@ -2,8 +2,9 @@
 from base import BaseResource, PipedriveAPI, CollectionResponse, dict_to_model
 from models import (
     User, Pipeline, Stage, SearchResult, Organization,
-    Deal, Activity, ActivityType
+    Deal, Activity, ActivityType, Person, Note
 )
+
 
 class UserResource(BaseResource):
     MODEL_CLASS = User
@@ -239,6 +240,75 @@ class ActivityTypeResource(BaseResource):
         response = self._bulk_delete(activities_ids)
         return response.json()
 
+
+class PersonResource(BaseResource):
+    MODEL_CLASS = Person
+    API_ACESSOR_NAME = 'person'
+    LIST_REQ_PATH = '/persons'
+    DETAIL_REQ_PATH = '/persons/{id}'
+    FIND_REQ_PATH = '/persons/find'
+    RELATED_ENTITIES_PATH = '/persons/{id}/{entity}'
+
+    def detail(self, resource_ids):
+        response = self._detail(resource_ids)
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def create(self, person):
+        response = self._create(data=person.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def update(self, person):
+        response = self._update(person.id, data=person.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def list(self, **params):
+        return CollectionResponse(self._list(params=params), self.MODEL_CLASS)
+
+    def find(self, term, **params):
+        return CollectionResponse(self._find(term, params=params), self.MODEL_CLASS)
+
+    def delete(self, person):
+        response = self._delete(person.id)
+        return response.json()
+
+    def bulk_delete(self, persons):
+        person_ids = [person.id for person in persons]
+
+        response = self._bulk_delete(person_ids)
+        return response.json()
+
+
+class NoteResource(BaseResource):
+    MODEL_CLASS = Note
+    API_ACESSOR_NAME = 'note'
+    LIST_REQ_PATH = '/notes'
+    DETAIL_REQ_PATH = '/notes/{id}'
+
+    def detail(self, resource_ids):
+        response = self._detail(resource_ids)
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def create(self, note):
+        response = self._create(data=note.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def update(self, note):
+        response = self._update(note.id, data=note.to_primitive())
+        return dict_to_model(response.json()['data'], self.MODEL_CLASS)
+
+    def list(self, **params):
+        return CollectionResponse(self._list(params=params), self.MODEL_CLASS)
+
+    def delete(self, note):
+        response = self._delete(note.id)
+        return response.json()
+
+    def bulk_delete(self, notes):
+        note_ids = [note.id for note in notes]
+
+        response = self._bulk_delete(note_ids)
+        return response.json()
+
 # Registers the resources
 for resource_class in [
     UserResource,
@@ -249,5 +319,7 @@ for resource_class in [
     DealResource,
     ActivityResource,
     ActivityTypeResource,
+    PersonResource,
+    NoteResource,
 ]:
     PipedriveAPI.register_resource(resource_class)

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -4,6 +4,7 @@ from schematics.types import DateType, BaseType
 from schematics.exceptions import ConversionError
 from base import dict_to_model
 
+
 class PipedriveDate(DateType):
     def to_native(self, value, context=None):
         return datetime.datetime.strptime(value, "%Y-%m-%d")

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -90,6 +90,9 @@ class PipedriveModelType(BaseType):
 
 class PipedriveListDictStringOrStringType(BaseType):
     """
+    Can be used as a base class for fields that receive different formats (list with dicts with strings or just
+    a string) from the Pipedrive API.
+
     Pipedrive inconsistently returns values for some fields, for example: "find" for a Person just returns a string
     for email even if there are multiple emails associated with that Person. "detail" for a Person returns a list
     containing a dict containing strings for emails. Because of this inconsistency we need to have a field that can
@@ -116,14 +119,20 @@ class PipedriveListDictStringOrStringType(BaseType):
 
 class PipedriveEmailType(PipedriveListDictStringOrStringType):
     """
-    We're just using these because the names don't suck as much.
+    Use this field type for models that can have multiple email addresses associated with them, such as Persons.
+    We're just using these, because they're more clear than the parent's name.
+
+    For more information see the parent's docstring.
     """
     pass
 
 
 class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
     """
-    We're just using these because the names don't suck as much.
+    Use this field type for models that can have multiple phone numbers associated with them, such as Persons.
+    We're just using these, because they're more clear than the parent's name.
+
+    For more information see the parent's docstring.
     """
     pass
 

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -74,7 +74,7 @@ class PipedriveModelType(BaseType):
         if isinstance(value, dict):
             return dict_to_model(value, self.model_class)
 
-        raise ConversionError(self.messages['value_type'] % self.model_class)            
+        raise ConversionError(self.messages['value_type'] % self.model_class)
 
     def to_primitive(self, value, context=None):
         if isinstance(value, self.model_class):
@@ -84,3 +84,37 @@ class PipedriveModelType(BaseType):
             return value['id']
 
         return value
+
+
+class PipedriveListDictStringOrStringType(BaseType):
+    """
+    Pipedrive inconsistently returns values for some fields, for example: "find" for a Person just returns a string
+    for email even if there are multiple emails associated with that Person. "detail" for a Person returns a list
+    containing a dict containing strings for emails. Because of this inconsistency we need to have a field that can
+    return the correct values even if the way they are represented changes. We are opting for the list-dict-string
+    because this allows us to better control these multiple values (email addresses, phone numbers etc.).
+    """
+    def to_native(self, value, context=None):
+        if isinstance(value, list):
+            return value
+        elif isinstance(value, basestring):
+            return [{'value': value}]
+
+    def to_primitive(self, value, context=None):
+        if isinstance(value, basestring):
+            value = [{'value': value}]
+        return value
+
+
+class PipedriveEmailType(PipedriveListDictStringOrStringType):
+    """
+    We're just using these because the names don't suck as much.
+    """
+    pass
+
+
+class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
+    """
+    We're just using these because the names don't suck as much.
+    """
+    pass

--- a/pipedrive/types.py
+++ b/pipedrive/types.py
@@ -99,7 +99,7 @@ class PipedriveListDictStringOrStringType(BaseType):
     def to_native(self, value, context=None):
         if isinstance(value, list):
             return value
-        elif isinstance(value, basestring):
+        elif is_string(value):
             return [{'value': value}]
 
     def to_primitive(self, value, context=None):
@@ -108,7 +108,7 @@ class PipedriveListDictStringOrStringType(BaseType):
         # So when you, for example, get a person with multiple email addresses and try to update his name Pipedrive
         # will screw up his email addresses. In that case it's just better to update manually or specify None for
         # the email addresses (which means it won't update them at all).
-        if not isinstance(value, basestring) and isinstance(value, Iterable):
+        if not is_string(value) and isinstance(value, Iterable):
             raise ValueError("Pipedrive can't handle iterable objects. You can either specify one value of type base"
                              "string which will update the first record, or specify None which won't update anything")
         return value
@@ -126,3 +126,13 @@ class PipedrivePhonenumberType(PipedriveListDictStringOrStringType):
     We're just using these because the names don't suck as much.
     """
     pass
+
+
+def is_string(value):
+    """
+    Check if value is a string. Python 2 and 3 compatible.
+    """
+    try:
+        return isinstance(value, basestring)
+    except NameError:
+        return isinstance(value, str)


### PR DESCRIPTION
Add Person and Note support.

Unfortunately the Pipedrive API returns relatively annoying values for the Person class which makes the whole thing quite difficult to use. You can retrieve a Person emails with detail or find; the first returns a list with dicts, the second just a string. We have to catch this and return uniform values, which should be the list with dicts so we can support the multiple email addresses. However, Pipedrive doesn't support update or creation with multiple values, so when we update or create a person (even if it was retrieved like this) we have to throw an error that this operation is not supported by Pipedrive. Ugly, but there is no other way without messing up existing data.

Loggi, let me know what you think. It would be nice if we could get this merged in your repo somehow :) This closes #1 and #2 